### PR TITLE
Implement From trait for finch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cbindgen = "0.6.0"
 [dependencies]
 backtrace = "0.3.4"
 error-chain = "0.11"
-finch = { version = "0.1.5", optional = true }
+finch = { version = "0.1.6", optional = true }
 lazy_static = "1.0.0"
 murmurhash3 = "~0.0.5"
 needletail = { version = "~0.1.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 lto=true
 
 [features]
-from-finch = ["finch"]
+from-finch = ["finch", "needletail"]
 
 [build-dependencies]
 cbindgen = "0.6.0"
@@ -26,4 +26,5 @@ error-chain = "0.11"
 finch = { version = "0.1.5", optional = true }
 lazy_static = "1.0.0"
 murmurhash3 = "~0.0.5"
+needletail = { version = "~0.1.4", optional = true }
 ordslice = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,16 @@ crate-type = ["cdylib", "rlib"]
 [profile.release]
 lto=true
 
+[features]
+from-finch = ["finch"]
+
 [build-dependencies]
 cbindgen = "0.6.0"
 
 [dependencies]
 backtrace = "0.3.4"
 error-chain = "0.11"
+finch = { version = "0.1.5", optional = true }
 lazy_static = "1.0.0"
 murmurhash3 = "~0.0.5"
 ordslice = "0.2.0"

--- a/src/from.rs
+++ b/src/from.rs
@@ -8,7 +8,7 @@ impl From<MinHashKmers> for KmerMinHash {
 
       let mut new_mh = KmerMinHash::new(
         values.len() as u32,
-        values.get(0).unwrap().kmer.len() as u32, 
+        values.get(0).unwrap().kmer.len() as u32,
         false,
         42,
         0,
@@ -16,7 +16,7 @@ impl From<MinHashKmers> for KmerMinHash {
       );
 
       let hash_with_abunds = values.iter()
-                                   .map(|x| (x.hash as u64, (x.count + x.extra_count) as u64))
+                                   .map(|x| (x.hash as u64, x.count as u64))
                                    .collect();
 
       new_mh.add_many_with_abund(hash_with_abunds);

--- a/src/from.rs
+++ b/src/from.rs
@@ -1,0 +1,27 @@
+use finch::minhashes::MinHashKmers;
+
+use ::KmerMinHash;
+
+impl From<MinHashKmers> for KmerMinHash {
+  fn from(other: MinHashKmers) -> KmerMinHash {
+      let values = other.into_vec();
+
+      let mut new_mh = KmerMinHash::new(
+        values.len() as u32,
+        values.get(0).unwrap().kmer.len() as u32, 
+        false,
+        42,
+        0,
+        true
+      );
+
+      let hash_with_abunds = values.iter()
+                                   .map(|x| (x.hash as u64, (x.count + x.extra_count) as u64))
+                                   .collect();
+
+      new_mh.add_many_with_abund(hash_with_abunds);
+
+      new_mh
+  }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ extern crate backtrace;
 extern crate murmurhash3;
 extern crate ordslice;
 
+#[cfg(feature = "from-finch")]
+extern crate finch;
+
 #[macro_use]
 extern crate error_chain;
 
@@ -16,6 +19,9 @@ pub mod utils;
 
 #[macro_use]
 pub mod ffi;
+
+#[cfg(feature = "from-finch")]
+pub mod from;
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -345,6 +351,22 @@ impl KmerMinHash {
             self.add_hash(*min);
         }
         Ok(())
+    }
+
+    pub fn add_many(&mut self, hashes: Vec<u64>) -> Result<()> {
+        for min in hashes.iter() {
+            self.add_hash(*min);
+        }
+        Ok(())
+    }
+
+    pub fn add_many_with_abund(&mut self, hashes: Vec<(u64, u64)>) -> Result<()> {
+        for item in hashes.iter() {
+            for _i in 0..item.1 {
+                self.add_hash(item.0);
+            }
+        }
+       Ok(())
     }
 
     pub fn count_common(&mut self, other: &KmerMinHash) -> Result<u64> {

--- a/tests/finch.rs
+++ b/tests/finch.rs
@@ -3,16 +3,25 @@ extern crate sourmash;
 #[cfg(feature = "from-finch")]
 extern crate finch;
 
+#[cfg(feature = "from-finch")]
+extern crate needletail;
+
+use std::collections::HashSet;
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
 use sourmash::KmerMinHash;
 
 #[cfg(feature = "from-finch")]
 use finch::minhashes::MinHashKmers;
 
+#[cfg(feature = "from-finch")]
+use needletail::kmer::canonical;
 
 #[cfg(feature = "from-finch")]
 #[test]
-fn from_finch() {
-    let mut a = KmerMinHash { num: 20, ksize: 10, .. Default::default() };
+fn finch_behavior() {
+    let mut a = KmerMinHash::new(20, 10, false, 42, 0, true);
     let mut b = MinHashKmers::new(20, 42);
 
     let seq = b"TGCCGCCCAGCACCGGGTGACTAGGTTGAGCCATGATTAACCTGCAATGA";
@@ -20,16 +29,59 @@ fn from_finch() {
     a.add_sequence(seq, false);
 
     for kmer in seq.windows(10) {
-        b.push(kmer, 0);
+        b.push(&canonical(kmer), 0);
     }
 
     let b_hashes = b.into_vec();
 
-    println!("{:?}", b_hashes.len());
-    println!("{:?}", a.mins.len());
+    let s1: HashSet<_> = HashSet::from_iter(a.mins.iter().map(|x| *x));
+    let s2: HashSet<_> = HashSet::from_iter(b_hashes.iter().map(|x| x.hash as u64));
+    let i1 = &s1 & &s2;
 
-    for item in b_hashes.iter() {
-        assert!(a.mins.contains(&(item.hash as u64)));
+    assert!(i1.len() == a.mins.len());
+    assert!(i1.len() == b_hashes.len());
+
+    if let Some(abunds) = a.abunds {
+        let smap: HashMap<_, _> = HashMap::from_iter(a.mins.iter().zip(abunds.iter()));
+        println!("{:?}", smap);
+        for item in b_hashes.iter() {
+            assert!(smap.contains_key(&(item.hash as u64)));
+            assert!(**smap.get(&(item.hash as u64)).unwrap() == ((item.count + item.extra_count) as u64));
+        }
+    }
+}
+
+#[cfg(feature = "from-finch")]
+#[test]
+fn from_finch() {
+    let mut a = KmerMinHash::new(20, 10, false, 42, 0, true);
+    let mut b = MinHashKmers::new(20, 42);
+
+    let seq = b"TGCCGCCCAGCACCGGGTGACTAGGTTGAGCCATGATTAACCTGCAATGA";
+
+    a.add_sequence(seq, false);
+
+    for kmer in seq.windows(10) {
+        b.push(&canonical(kmer), 0);
     }
 
+    let c = KmerMinHash::from(b);
+
+    let s1: HashSet<_> = HashSet::from_iter(a.mins.iter().map(|x| *x));
+    let s2: HashSet<_> = HashSet::from_iter(c.mins.iter().map(|x| *x));
+    let i1 = &s1 & &s2;
+
+    assert!(i1.len() == a.mins.len());
+    assert!(i1.len() == c.mins.len());
+
+    if let Some(a_abunds) = a.abunds {
+        if let Some(c_abunds) = c.abunds {
+            let a_smap: HashMap<_, _> = HashMap::from_iter(a.mins.iter().zip(a_abunds.iter()));
+            let c_smap: HashMap<_, _> = HashMap::from_iter(c.mins.iter().zip(c_abunds.iter()));
+            for item in a_smap.iter() {
+                assert!(c_smap.contains_key(*item.0));
+                assert!(c_smap.get(*item.0).unwrap() == item.1);
+            }
+        }
+    }
 }

--- a/tests/finch.rs
+++ b/tests/finch.rs
@@ -1,0 +1,35 @@
+extern crate sourmash;
+
+#[cfg(feature = "from-finch")]
+extern crate finch;
+
+use sourmash::KmerMinHash;
+
+#[cfg(feature = "from-finch")]
+use finch::minhashes::MinHashKmers;
+
+
+#[cfg(feature = "from-finch")]
+#[test]
+fn from_finch() {
+    let mut a = KmerMinHash { num: 20, ksize: 10, .. Default::default() };
+    let mut b = MinHashKmers::new(20, 42);
+
+    let seq = b"TGCCGCCCAGCACCGGGTGACTAGGTTGAGCCATGATTAACCTGCAATGA";
+
+    a.add_sequence(seq, false);
+
+    for kmer in seq.windows(10) {
+        b.push(kmer, 0);
+    }
+
+    let b_hashes = b.into_vec();
+
+    println!("{:?}", b_hashes.len());
+    println!("{:?}", a.mins.len());
+
+    for item in b_hashes.iter() {
+        assert!(a.mins.contains(&(item.hash as u64)));
+    }
+
+}


### PR DESCRIPTION
Trying out the `From` trait, and `finch` seemed like a good first try (since I can check if the implementations are compatible).

pinging @bovee just to make sure I interpreted the `finch` struct correctly: in sourmash we keep the abundance of a k-mer, but finch uses `count` and `extra_count`. What is the difference between them, and can I just sum them up to have the total count?

The other thing was figuring out what is the k-mer length, since this is not saved in the struct. I solved this by checking the first value from `.into_vec()`