### PR TITLE
wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 description = "MinHash sketches for genomic data"
 repository = "https://github.com/luizirber/sourmash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cbindgen = "0.6.1"
 
 [dependencies]
 backtrace = "0.3.4"
+cfg-if = "0.1"
 error-chain = "0.12"
 finch = { version = "0.1.6", optional = true }
 lazy_static = "1.0.0"
@@ -33,3 +34,7 @@ ordslice = "0.3.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0.2"
+
+#TODO: wasm-pack can't check optionals or this kind of config yet...
+# [target. 'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,10 @@ needletail = { version = "~0.2.1", optional = true }
 ordslice = "0.3.0"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0.2"
+serde_json = "1.0"
 
 #TODO: wasm-pack can't check optionals or this kind of config yet...
 # [target. 'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
+[dependencies.wasm-bindgen]
+version = "^0.2"
+features = ["serde-serialize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sourmash"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 description = "MinHash sketches for genomic data"
 repository = "https://github.com/luizirber/sourmash-rust"

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,8 @@ test:
 target/sourmash.h: src/lib.rs src/ffi.rs src/errors.rs
 	RUST_BACKTRACE=1 cbindgen --clean -c cbindgen.toml -o $@
 
+wasm:
+#	wasm-pack init --mode no-installs
+	wasm-pack init
+
 .phony: test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,11 @@ cfg_if! {
         #[wasm_bindgen]
         #[derive(Debug, Clone, PartialEq)]
         pub struct KmerMinHash {
-            pub num: u32,
-            pub ksize: u32,
-            pub is_protein: bool,
-            pub seed: u64,
-            pub max_hash: u64,
+            num: u32,
+            ksize: u32,
+            is_protein: bool,
+            seed: u64,
+            max_hash: u64,
             mins: Vec<u64>,
             abunds: Option<Vec<u64>>,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-#![cfg_attr(
-    target_arch = "wasm32",
-    feature(use_extern_macros, wasm_custom_section, wasm_import_module)
-)]
+#![cfg_attr(target_arch = "wasm32", feature(use_extern_macros))]
 
 extern crate backtrace;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(target_arch = "wasm32", feature(use_extern_macros))]
-
 extern crate backtrace;
 #[macro_use]
 extern crate cfg_if;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -38,10 +38,12 @@ impl KmerMinHash {
         self.add_sequence(buf.as_bytes(), true);
     }
 
+    /*
     #[wasm_bindgen]
     pub fn add_hash_js(&mut self, h: u64) {
         self.add_hash(h);
     }
+    */
 
     #[wasm_bindgen]
     pub fn to_json(&mut self) -> String {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,50 @@
+use wasm_bindgen::prelude::*;
+
+use serde_json;
+
+use KmerMinHash;
+
+#[wasm_bindgen]
+impl KmerMinHash {
+    #[wasm_bindgen(constructor)]
+    pub fn new_with_scaled(
+        num: u32,
+        ksize: u32,
+        is_protein: bool,
+        seed: u32,
+        scaled: u32,
+        track_abundance: bool,
+    ) -> KmerMinHash {
+        let max_hash = if num != 0 {
+            0
+        } else if scaled == 0 {
+            u64::max_value()
+        } else {
+            u64::max_value() / scaled as u64
+        };
+
+        KmerMinHash::new(
+            num,
+            ksize,
+            is_protein,
+            seed as u64,
+            max_hash,
+            track_abundance,
+        )
+    }
+
+    #[wasm_bindgen]
+    pub fn add_sequence_js(&mut self, buf: &str) {
+        self.add_sequence(buf.as_bytes(), true);
+    }
+
+    #[wasm_bindgen]
+    pub fn add_hash_js(&mut self, h: u64) {
+        self.add_hash(h);
+    }
+
+    #[wasm_bindgen]
+    pub fn to_json(&mut self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -38,13 +38,6 @@ impl KmerMinHash {
         self.add_sequence(buf.as_bytes(), true);
     }
 
-    /*
-    #[wasm_bindgen]
-    pub fn add_hash_js(&mut self, h: u64) {
-        self.add_hash(h);
-    }
-    */
-
     #[wasm_bindgen]
     pub fn to_json(&mut self) -> String {
         serde_json::to_string(self).unwrap()


### PR DESCRIPTION
Use `wasm-bindgen` to annotate structs and methods for JS, and generate a webassembly NPM package using `wasm-pack`

## Issues/weirdness:
- `wasm-pack` doesn't support conditional include/features in `Cargo.toml` and fails if `wasm-bindgen` is not explicitly added as a dependency.
- I ended up re-declaring the `KmerMinHash` struct depending on the target platform... There is probably a better way, but don't know how to do it. For now the `cfg_if` trick worked.

## Additional notes
- Even tho this is not merged yet, the package is available in NPM: https://www.npmjs.com/package/sourmash
- I'm writing the drag and drop demo at https://github.com/luizirber/wort-dnd